### PR TITLE
Average from multiple simulations

### DIFF
--- a/GeneticProgramming.py
+++ b/GeneticProgramming.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import matplotlib.pyplot as plt
 
-from Simulation import run_simulation
+from Simulation import fitness_function
 
 def plot_logbook(logbook):
     min_values = logbook.select("min")
@@ -29,14 +29,14 @@ def plot_tree(nodes, edges, labels):
     plt.show()
 
 def sequence3(input1, input2, input3):
-        for input in [input1, input2, input3]:
-            if input == False:
-                return False
-            elif input == True:
-                continue
-            else:
-                return input
-        return True
+    for input in [input1, input2, input3]:
+        if input == False:
+            return False
+        elif input == True:
+            continue
+        else:
+            return input
+    return True
 
 def sequence2(input1, input2):
     for input in [input1, input2]:
@@ -54,7 +54,7 @@ def selector2(input1, input2):
             continue
         else:
             return input
-    return 'do_nothing'
+    return False
 
 def selector3(input1, input2, input3):
     for input in [input1, input2, input3]:
@@ -62,7 +62,7 @@ def selector3(input1, input2, input3):
             continue
         else:
             return input
-    return 'do_nothing'
+    return False
 
 if __name__ == '__main__':
     pset = gp.PrimitiveSet("main", 2)
@@ -76,7 +76,6 @@ if __name__ == '__main__':
     pset.renameArguments(ARG1="predator_nearby")
     pset.addTerminal('go_to_food')
     pset.addTerminal('go_from_predator')
-    pset.addTerminal('do_nothing')
 
     creator.create("FitnessMax", base.Fitness, weights=(1.0,))
     creator.create("Individual", gp.PrimitiveTree, fitness=creator.FitnessMax)
@@ -92,7 +91,7 @@ if __name__ == '__main__':
     def eval_prey(individual):
         routine = gp.compile(individual, pset)
 
-        res = run_simulation(routine)
+        res = fitness_function(routine)
 
         return res,
 
@@ -103,7 +102,7 @@ if __name__ == '__main__':
     toolbox.register("expr_mut", gp.genFull, min_=1, max_=3)
     toolbox.register("mutate", gp.mutUniform, expr=toolbox.expr_mut, pset=pset)
 
-    pop = toolbox.population(n=10)
+    pop = toolbox.population(n=20)
     hof = tools.HallOfFame(1)
     stats = tools.Statistics(lambda ind: ind.fitness.values)
     stats.register("avg", np.mean)
@@ -111,7 +110,7 @@ if __name__ == '__main__':
     stats.register("min", np.min)
     stats.register("max", np.max)
 
-    _, logbook = algorithms.eaSimple(pop, toolbox, 0.5, 0.2, 50, stats, halloffame=hof)
+    _, logbook = algorithms.eaSimple(pop, toolbox, 0.5, 0.2, 20, stats, halloffame=hof)
     plot_logbook(logbook)
     nodes,edges,labels = gp.graph(hof[0])
     plot_tree(nodes, edges, labels)

--- a/Simulation.py
+++ b/Simulation.py
@@ -7,6 +7,8 @@ from GrassAgent import *
 from GP_Agents import Prey, Predator
 from matplotlib import pyplot as plt
 
+def fitness_function(prey_function):
+    return np.mean([run_simulation(prey_function) for _ in range(3)])
 
 def run_simulation(prey_function, print_move=False):
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/58685838/200690985-7f4a6a4e-d673-47f4-b67f-7a0e6fb7f708.png)
Gdy biorę średnią z wielu symulacji to: zwiększyły się wartości min, obniżyły się wartości avg i max (są to dość naturalne konsekwencje).
TODO:
- [x] uruchamianie równolegle symulacji/równoległe ewaluowanie wartości funkcji fitnessu, porównanie czasu 122s vs 884 s na moim laptopie.

Część kodu wyciągnąłem przed `if __name__ == '__main__':`, bez tego mi to nie działało:
```
I am using deap. I encountered the exact same issue and made it work by following exactly as the example mentioned https://github.com/DEAP/deap/blob/master/examples/ga/onemax_mp.py.
Make sure the toolbox.register comes before the if name == 'main' and pool=multiprocessing.Pool(processes=4) comes after if name == 'main'.
```
Powiązane issue: https://github.com/rsteca/sklearn-deap/issues/59

O ile dobrze rozumiem to drzewko takie jak:
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/58685838/200788204-016b6f9c-4f6f-4d42-be76-133f320dd197.png">
zwraca zawsze `go_from_predator`. Zwracane polityki zazwyczaj zwracają ciągle `run_from_predator` - co można zrobić żeby to poprawić?